### PR TITLE
Adding support for unmanaged memory

### DIFF
--- a/core/examples/CMakeLists.txt
+++ b/core/examples/CMakeLists.txt
@@ -26,4 +26,7 @@ morpheus_add_executable_and_test(Examples_MatrixOperations SOURCES
 morpheus_add_executable_and_test(Examples_Multiply SOURCES
                                  Examples_Multiply.cpp)
 
+morpheus_add_executable_and_test(Examples_Unmanaged SOURCES
+                                 Examples_Unmanaged.cpp)
+
 morpheus_add_executable_and_test(Examples_Version SOURCES Examples_Version.cpp)

--- a/core/examples/Examples_Unmanaged.cpp
+++ b/core/examples/Examples_Unmanaged.cpp
@@ -1,0 +1,60 @@
+/**
+ * Exampels_Unamanged.cpp
+ *
+ * EPCC, The University of Edinburgh
+ *
+ * (c) 2021 The University of Edinburgh
+ *
+ * Contributing Authors:
+ * Christodoulos Stylianou (c.stylianou@ed.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <Morpheus_Core.hpp>
+#include <iostream>
+
+using index_type   = int;
+using value_type   = double;
+using memory_trait = Kokkos::MemoryUnmanaged;
+
+using vec = Morpheus::DenseVector<value_type, memory_trait>;
+
+int main(int argc, char* argv[]) {
+  Morpheus::initialize(argc, argv);
+  {
+    index_type n  = 15;
+    value_type* v = (value_type*)malloc(n * sizeof(value_type));
+
+    for (index_type i = 0; i < n; i++) {
+      v[i] = i * n;
+    }
+
+    {
+      vec x("x", n, v);
+      typename vec::HostMirror xm = Morpheus::create_mirror_container(x);
+      Morpheus::print(xm);
+
+      xm(5) = -15;
+    }
+
+    for (index_type i = 0; i < n; i++) {
+      std::cout << "\t [" << i << "] : " << v[i] << std::endl;
+    }
+
+    free(v);
+  }
+  Morpheus::finalize();
+
+  return 0;
+}

--- a/core/examples/Examples_Unmanaged.cpp
+++ b/core/examples/Examples_Unmanaged.cpp
@@ -29,30 +29,78 @@ using value_type   = double;
 using memory_trait = Kokkos::MemoryUnmanaged;
 
 using vec = Morpheus::DenseVector<value_type, memory_trait>;
+using coo = Morpheus::CooMatrix<value_type, memory_trait>;
 
 int main(int argc, char* argv[]) {
   Morpheus::initialize(argc, argv);
   {
-    index_type n  = 15;
-    value_type* v = (value_type*)malloc(n * sizeof(value_type));
-
-    for (index_type i = 0; i < n; i++) {
-      v[i] = i * n;
-    }
-
+    // DenseVector unmanaged
     {
-      vec x("x", n, v);
-      typename vec::HostMirror xm = Morpheus::create_mirror_container(x);
-      Morpheus::print(xm);
+      index_type n  = 15;
+      value_type* v = (value_type*)malloc(n * sizeof(value_type));
 
-      xm(5) = -15;
+      for (index_type i = 0; i < n; i++) {
+        v[i] = i * n;
+      }
+
+      {
+        vec x("x", n, v);
+        typename vec::HostMirror xm = Morpheus::create_mirror_container(x);
+        Morpheus::print(xm);
+
+        xm(5) = -15;
+      }
+
+      for (index_type i = 0; i < n; i++) {
+        std::cout << "\t [" << i << "] : " << v[i] << std::endl;
+      }
+
+      free(v);
     }
+    // CooMatrix unmanaged
+    {
+      index_type M = 4, N = 3, NNZ = 6;
+      value_type* vals = (value_type*)malloc(NNZ * sizeof(value_type));
+      index_type* rind = (index_type*)malloc(NNZ * sizeof(index_type));
+      index_type* cind = (index_type*)malloc(NNZ * sizeof(index_type));
 
-    for (index_type i = 0; i < n; i++) {
-      std::cout << "\t [" << i << "] : " << v[i] << std::endl;
+      rind[0] = 0;
+      cind[0] = 0;
+      vals[0] = 10;
+      rind[1] = 0;
+      cind[1] = 2;
+      vals[1] = 20;
+      rind[2] = 2;
+      cind[2] = 2;
+      vals[2] = 30;
+      rind[3] = 3;
+      cind[3] = 0;
+      vals[3] = 40;
+      rind[4] = 3;
+      cind[4] = 1;
+      vals[4] = 50;
+      rind[5] = 3;
+      cind[5] = 2;
+      vals[5] = 60;
+
+      {
+        coo A("A", M, N, NNZ, rind, cind, vals);
+        typename coo::HostMirror Am = Morpheus::create_mirror_container(A);
+        Morpheus::print(A);
+
+        A.row_indices(2) = -15;
+        A.values(5)      = -15;
+      }
+
+      for (index_type i = 0; i < NNZ; i++) {
+        std::cout << "\t [" << i << "] : (" << rind[i] << ", " << cind[i]
+                  << ", " << vals[i] << ")" << std::endl;
+      }
+
+      free(vals);
+      free(rind);
+      free(cind);
     }
-
-    free(v);
   }
   Morpheus::finalize();
 

--- a/core/examples/Examples_Unmanaged.cpp
+++ b/core/examples/Examples_Unmanaged.cpp
@@ -28,9 +28,10 @@ using index_type   = int;
 using value_type   = double;
 using memory_trait = Kokkos::MemoryUnmanaged;
 
-using vec = Morpheus::DenseVector<value_type, memory_trait>;
-using coo = Morpheus::CooMatrix<value_type, memory_trait>;
-using csr = Morpheus::CsrMatrix<value_type, memory_trait>;
+using vec    = Morpheus::DenseVector<value_type, memory_trait>;
+using matrix = Morpheus::DenseMatrix<value_type, memory_trait>;
+using coo    = Morpheus::CooMatrix<value_type, memory_trait>;
+using csr    = Morpheus::CsrMatrix<value_type, memory_trait>;
 
 int main(int argc, char* argv[]) {
   Morpheus::initialize(argc, argv);
@@ -57,6 +58,34 @@ int main(int argc, char* argv[]) {
       }
 
       free(v);
+    }
+    // DenseMatrix unmanaged
+    {
+      index_type n    = 5;
+      value_type* mat = (value_type*)malloc(n * n * sizeof(value_type*));
+
+      for (index_type i = 0; i < n; i++) {
+        for (index_type j = 0; j < n; j++) {
+          mat[i * n + j] = i * n + j;
+        }
+      }
+
+      {
+        matrix m("m", n, n, mat);
+        typename matrix::HostMirror mm = Morpheus::create_mirror_container(m);
+        Morpheus::print(mm);
+
+        mm(2, 2) = -15;
+      }
+
+      for (index_type i = 0; i < n; i++) {
+        for (index_type j = 0; j < n; j++) {
+          std::cout << mat[i * n + j] << "\t";
+        }
+        std::cout << std::endl;
+      }
+
+      free(mat);
     }
     // CooMatrix unmanaged
     {

--- a/core/examples/Examples_Unmanaged.cpp
+++ b/core/examples/Examples_Unmanaged.cpp
@@ -30,6 +30,7 @@ using memory_trait = Kokkos::MemoryUnmanaged;
 
 using vec = Morpheus::DenseVector<value_type, memory_trait>;
 using coo = Morpheus::CooMatrix<value_type, memory_trait>;
+using csr = Morpheus::CsrMatrix<value_type, memory_trait>;
 
 int main(int argc, char* argv[]) {
   Morpheus::initialize(argc, argv);
@@ -99,6 +100,55 @@ int main(int argc, char* argv[]) {
 
       free(vals);
       free(rind);
+      free(cind);
+    }
+    // CsrMatrix unmanaged
+    {
+      index_type M = 4, N = 3, NNZ = 6;
+      value_type* vals = (value_type*)malloc(NNZ * sizeof(value_type));
+      index_type* roff = (index_type*)malloc((M + 1) * sizeof(index_type));
+      index_type* cind = (index_type*)malloc(NNZ * sizeof(index_type));
+
+      roff[0] = 0;
+      roff[1] = 2;
+      roff[2] = 3;
+      roff[3] = 5;
+      roff[4] = 6;
+
+      cind[0] = 0;
+      cind[1] = 1;
+      cind[2] = 2;
+      cind[3] = 0;
+      cind[4] = 2;
+      cind[5] = 1;
+
+      vals[0] = 10;
+      vals[1] = 20;
+      vals[2] = 30;
+      vals[3] = 40;
+      vals[4] = 50;
+      vals[5] = 60;
+
+      {
+        csr A("A", M, N, NNZ, roff, cind, vals);
+        typename csr::HostMirror Am = Morpheus::create_mirror_container(A);
+        Morpheus::print(A);
+
+        A.row_offsets(2) = -15;
+        A.values(5)      = -15;
+      }
+
+      for (index_type i = 0; i < M; i++) {
+        std::cout << "\t [" << i << "] : " << roff[i] << std::endl;
+      }
+      std::cout << std::endl;
+      for (index_type i = 0; i < NNZ; i++) {
+        std::cout << "\t [" << i << "] : (" << cind[i] << ", " << vals[i] << ")"
+                  << std::endl;
+      }
+
+      free(vals);
+      free(roff);
       free(cind);
     }
   }

--- a/core/src/Morpheus_CooMatrix.hpp
+++ b/core/src/Morpheus_CooMatrix.hpp
@@ -52,6 +52,7 @@ class CooMatrix : public Impl::MatrixBase<CooMatrix, ValueType, Properties...> {
   using memory_space    = typename traits::memory_space;
   using execution_space = typename traits::execution_space;
   using device_type     = typename traits::device_type;
+  using memory_traits   = typename traits::memory_traits;
   using HostMirror      = typename traits::HostMirror;
 
   using pointer         = typename traits::pointer;
@@ -59,16 +60,18 @@ class CooMatrix : public Impl::MatrixBase<CooMatrix, ValueType, Properties...> {
   using reference       = typename traits::reference;
   using const_reference = typename traits::const_reference;
 
-  using index_array_type       = Morpheus::DenseVector<index_type, index_type,
-                                                 array_layout, execution_space>;
+  using index_array_type =
+      Morpheus::DenseVector<index_type, index_type, array_layout,
+                            execution_space, memory_traits>;
   using const_index_array_type = const index_array_type;
   using index_array_pointer    = typename index_array_type::value_array_pointer;
   using index_array_reference =
       typename index_array_type::value_array_reference;
   using const_index_array_reference = const index_array_reference;
 
-  using value_array_type       = Morpheus::DenseVector<value_type, index_type,
-                                                 array_layout, execution_space>;
+  using value_array_type =
+      Morpheus::DenseVector<value_type, index_type, array_layout,
+                            execution_space, memory_traits>;
   using const_value_array_type = const value_array_type;
   using value_array_pointer    = typename value_array_type::value_array_pointer;
   using value_array_reference =
@@ -101,6 +104,19 @@ class CooMatrix : public Impl::MatrixBase<CooMatrix, ValueType, Properties...> {
         _row_indices(rind),
         _column_indices(cind),
         _values(vals) {}
+
+  template <typename ValuePtr, typename IndexPtr>
+  explicit inline CooMatrix(
+      const std::string name, const index_type num_rows,
+      const index_type num_cols, const index_type num_entries,
+      IndexPtr rind_ptr, IndexPtr cind_ptr, ValuePtr vals_ptr,
+      typename std::enable_if<std::is_pointer<ValuePtr>::value &&
+                              std::is_pointer<IndexPtr>::value>::type * =
+          nullptr)
+      : base(name + "CooMatrix", num_rows, num_cols, num_entries),
+        _row_indices(size_t(num_entries), rind_ptr),
+        _column_indices(size_t(num_entries), cind_ptr),
+        _values(size_t(num_entries), vals_ptr) {}
 
   inline CooMatrix(const std::string name, const index_type num_rows,
                    const index_type num_cols, const index_type num_entries)

--- a/core/src/Morpheus_CooMatrix.hpp
+++ b/core/src/Morpheus_CooMatrix.hpp
@@ -113,7 +113,7 @@ class CooMatrix : public Impl::MatrixBase<CooMatrix, ValueType, Properties...> {
       typename std::enable_if<std::is_pointer<ValuePtr>::value &&
                               std::is_pointer<IndexPtr>::value>::type * =
           nullptr)
-      : base(name + "CooMatrix", num_rows, num_cols, num_entries),
+      : base(name + "CooMatrix_Unmanged", num_rows, num_cols, num_entries),
         _row_indices(size_t(num_entries), rind_ptr),
         _column_indices(size_t(num_entries), cind_ptr),
         _values(size_t(num_entries), vals_ptr) {}

--- a/core/src/Morpheus_CooMatrix.hpp
+++ b/core/src/Morpheus_CooMatrix.hpp
@@ -113,7 +113,7 @@ class CooMatrix : public Impl::MatrixBase<CooMatrix, ValueType, Properties...> {
       typename std::enable_if<std::is_pointer<ValuePtr>::value &&
                               std::is_pointer<IndexPtr>::value>::type * =
           nullptr)
-      : base(name + "CooMatrix_Unmanged", num_rows, num_cols, num_entries),
+      : base(name + "CooMatrix_Unmanaged", num_rows, num_cols, num_entries),
         _row_indices(size_t(num_entries), rind_ptr),
         _column_indices(size_t(num_entries), cind_ptr),
         _values(size_t(num_entries), vals_ptr) {}

--- a/core/src/Morpheus_CsrMatrix.hpp
+++ b/core/src/Morpheus_CsrMatrix.hpp
@@ -114,7 +114,7 @@ class CsrMatrix : public Impl::MatrixBase<CsrMatrix, ValueType, Properties...> {
       typename std::enable_if<std::is_pointer<ValuePtr>::value &&
                               std::is_pointer<IndexPtr>::value>::type * =
           nullptr)
-      : base(name + "CsrMatrix_Unmanged", num_rows, num_cols, num_entries),
+      : base(name + "CsrMatrix_Unmanaged", num_rows, num_cols, num_entries),
         _row_offsets(num_rows + 1, roff_ptr),
         _column_indices(num_entries, cind_ptr),
         _values(num_entries, vals_ptr) {}

--- a/core/src/Morpheus_CsrMatrix.hpp
+++ b/core/src/Morpheus_CsrMatrix.hpp
@@ -53,6 +53,7 @@ class CsrMatrix : public Impl::MatrixBase<CsrMatrix, ValueType, Properties...> {
   using memory_space    = typename traits::memory_space;
   using execution_space = typename traits::execution_space;
   using device_type     = typename traits::device_type;
+  using memory_traits   = typename traits::memory_traits;
   using HostMirror      = typename traits::HostMirror;
 
   using pointer         = typename traits::pointer;
@@ -60,16 +61,18 @@ class CsrMatrix : public Impl::MatrixBase<CsrMatrix, ValueType, Properties...> {
   using reference       = typename traits::reference;
   using const_reference = typename traits::const_reference;
 
-  using index_array_type       = Morpheus::DenseVector<index_type, index_type,
-                                                 array_layout, execution_space>;
+  using index_array_type =
+      Morpheus::DenseVector<index_type, index_type, array_layout,
+                            execution_space, memory_traits>;
   using const_index_array_type = const index_array_type;
   using index_array_pointer    = typename index_array_type::value_array_pointer;
   using index_array_reference =
       typename index_array_type::value_array_reference;
   using const_index_array_reference = const index_array_reference;
 
-  using value_array_type       = Morpheus::DenseVector<value_type, index_type,
-                                                 array_layout, execution_space>;
+  using value_array_type =
+      Morpheus::DenseVector<value_type, index_type, array_layout,
+                            execution_space, memory_traits>;
   using const_value_array_type = const value_array_type;
   using value_array_pointer    = typename value_array_type::value_array_pointer;
   using value_array_reference =
@@ -102,6 +105,19 @@ class CsrMatrix : public Impl::MatrixBase<CsrMatrix, ValueType, Properties...> {
         _row_offsets(roff),
         _column_indices(cind),
         _values(vals) {}
+
+  template <typename ValuePtr, typename IndexPtr>
+  explicit inline CsrMatrix(
+      const std::string name, const index_type num_rows,
+      const index_type num_cols, const index_type num_entries,
+      IndexPtr roff_ptr, IndexPtr cind_ptr, ValuePtr vals_ptr,
+      typename std::enable_if<std::is_pointer<ValuePtr>::value &&
+                              std::is_pointer<IndexPtr>::value>::type * =
+          nullptr)
+      : base(name + "CsrMatrix_Unmanged", num_rows, num_cols, num_entries),
+        _row_offsets(num_rows + 1, roff_ptr),
+        _column_indices(num_entries, cind_ptr),
+        _values(num_entries, vals_ptr) {}
 
   inline CsrMatrix(const std::string name, const index_type num_rows,
                    const index_type num_cols, const index_type num_entries)

--- a/core/src/Morpheus_DenseVector.hpp
+++ b/core/src/Morpheus_DenseVector.hpp
@@ -91,7 +91,7 @@ class DenseVector
       const std::string name, index_type n, ValuePtr ptr,
       typename std::enable_if<std::is_pointer<ValuePtr>::value>::type* =
           nullptr)
-      : _name(name + "Vector_ptr"), _size(n), _values(ptr, size_t(n)) {
+      : _name(name + "Vector_Unmanaged"), _size(n), _values(ptr, size_t(n)) {
     static_assert(std::is_same<value_array_pointer, ValuePtr>::value,
                   "Constructing DenseVector to wrap user memory must supply "
                   "matching pointer type");
@@ -102,7 +102,7 @@ class DenseVector
       index_type n, ValuePtr ptr,
       typename std::enable_if<std::is_pointer<ValuePtr>::value>::type* =
           nullptr)
-      : _name("Vector_ptr"), _size(n), _values(ptr, size_t(n)) {
+      : _name("Vector_Unmanaged"), _size(n), _values(ptr, size_t(n)) {
     static_assert(std::is_same<value_array_pointer, ValuePtr>::value,
                   "Constructing DenseVector to wrap user memory must supply "
                   "matching pointer type");

--- a/core/src/Morpheus_DenseVector.hpp
+++ b/core/src/Morpheus_DenseVector.hpp
@@ -91,7 +91,9 @@ class DenseVector
       typename std::enable_if<std::is_pointer<ValuePtr>::value>::type* =
           nullptr)
       : _name(name + "Vector_ptr"), _size(n), _values(ptr, size_t(n)) {
-    // assign(n, val);
+    static_assert(std::is_same<value_array_pointer, ValuePtr>::value,
+                  "Constructing DenseVector to wrap user memory must supply "
+                  "matching pointer type");
   }
 
   template <typename ValuePtr>
@@ -100,7 +102,9 @@ class DenseVector
       typename std::enable_if<std::is_pointer<ValuePtr>::value>::type* =
           nullptr)
       : _name("Vector_ptr"), _size(n), _values(ptr, size_t(n)) {
-    // assign(n, val);
+    static_assert(std::is_same<value_array_pointer, ValuePtr>::value,
+                  "Constructing DenseVector to wrap user memory must supply "
+                  "matching pointer type");
   }
 
   template <typename Generator>

--- a/core/src/Morpheus_DenseVector.hpp
+++ b/core/src/Morpheus_DenseVector.hpp
@@ -53,6 +53,7 @@ class DenseVector
   using memory_space    = typename traits::memory_space;
   using execution_space = typename traits::execution_space;
   using device_type     = typename traits::device_type;
+  using memory_traits   = typename traits::memory_traits;
   using HostMirror      = typename traits::HostMirror;
 
   using pointer         = typename traits::pointer;
@@ -61,7 +62,7 @@ class DenseVector
   using const_reference = typename traits::const_reference;
 
   using value_array_type =
-      Kokkos::View<value_type*, array_layout, execution_space>;
+      Kokkos::View<value_type*, array_layout, execution_space, memory_traits>;
   using value_array_pointer   = typename value_array_type::pointer_type;
   using value_array_reference = typename value_array_type::reference_type;
 

--- a/core/src/Morpheus_DenseVector.hpp
+++ b/core/src/Morpheus_DenseVector.hpp
@@ -84,6 +84,25 @@ class DenseVector
       : _name("Vector"), _size(n), _values("Vector", size_t(n)) {
     assign(n, val);
   }
+
+  template <typename ValuePtr>
+  explicit DenseVector(
+      const std::string name, index_type n, ValuePtr ptr,
+      typename std::enable_if<std::is_pointer<ValuePtr>::value>::type* =
+          nullptr)
+      : _name(name + "Vector_ptr"), _size(n), _values(ptr, size_t(n)) {
+    // assign(n, val);
+  }
+
+  template <typename ValuePtr>
+  explicit DenseVector(
+      index_type n, ValuePtr ptr,
+      typename std::enable_if<std::is_pointer<ValuePtr>::value>::type* =
+          nullptr)
+      : _name("Vector_ptr"), _size(n), _values(ptr, size_t(n)) {
+    // assign(n, val);
+  }
+
   template <typename Generator>
   inline DenseVector(const std::string name, index_type n, Generator rand_pool,
                      const value_type range_low, const value_type range_high)

--- a/core/src/Morpheus_DynamicMatrix.hpp
+++ b/core/src/Morpheus_DynamicMatrix.hpp
@@ -56,6 +56,7 @@ class DynamicMatrix
   using memory_space    = typename traits::memory_space;
   using execution_space = typename traits::execution_space;
   using device_type     = typename traits::device_type;
+  using memory_traits   = typename traits::memory_traits;
   using HostMirror      = typename traits::HostMirror;
 
   using pointer         = typename traits::pointer;

--- a/core/src/impl/Morpheus_ContainerTraits.hpp
+++ b/core/src/impl/Morpheus_ContainerTraits.hpp
@@ -44,6 +44,7 @@ namespace Impl {
  *  - ContainerTraits<ValueType, IndexType, ArrayLayout>
  *  - ContainerTraits<ValueType, IndexType, ArrayLayout, Space>
  *  - ContainerTraits<ValueType, ArrayLayout, Space>
+ *  - ContainerTraits<ValueType, IndexType, ArrayLayout, Space, MemoryTraits>
  */
 template <typename ValueType, class... Properties>
 struct ContainerTraits_Impl;
@@ -55,6 +56,7 @@ struct ContainerTraits_Impl<void> {
   using execution_space = void;
   using memory_space    = void;
   using HostMirrorSpace = void;
+  using memory_traits   = void;
 };
 
 template <class... Prop>
@@ -70,13 +72,16 @@ struct ContainerTraits_Impl<void, void, Prop...> {
       typename ContainerTraits_Impl<void, Prop...>::memory_space;
   using HostMirrorSpace =
       typename ContainerTraits_Impl<void, Prop...>::HostMirrorSpace;
+  using memory_traits =
+      typename ContainerTraits_Impl<void, Prop...>::memory_traits;
 };
 
 template <typename IndexType, class... Prop>
 struct ContainerTraits_Impl<
     typename std::enable_if_t<std::is_integral<IndexType>::value>, IndexType,
     Prop...> {
-  // Specify index type, keep subsequent layout and space arguments
+  // Specify index type
+  // Keep subsequent layout, space and memory trait arguments
 
   using index_type = IndexType;
   using array_layout =
@@ -87,6 +92,8 @@ struct ContainerTraits_Impl<
       typename ContainerTraits_Impl<void, Prop...>::memory_space;
   using HostMirrorSpace =
       typename ContainerTraits_Impl<void, Prop...>::HostMirrorSpace;
+  using memory_traits =
+      typename ContainerTraits_Impl<void, Prop...>::memory_traits;
 };
 
 template <typename ArrayLayout, class... Prop>
@@ -94,14 +101,10 @@ struct ContainerTraits_Impl<
     typename std::enable_if_t<
         Kokkos::Impl::is_array_layout<ArrayLayout>::value>,
     ArrayLayout, Prop...> {
-  // Specify Layout, Space should be the only subsequent argument.
+  // Specify Layout
+  // Keep Space and MemoryTraits arguments
 
-  static_assert(
-      std::is_same<typename ContainerTraits_Impl<void, Prop...>::array_layout,
-                   void>::value,
-      "Only one Layout template argument");
-
-  using index_type   = typename ContainerTraits_Impl<void, Prop...>::index_type;
+  using index_type   = void;
   using array_layout = ArrayLayout;
   using execution_space =
       typename ContainerTraits_Impl<void, Prop...>::execution_space;
@@ -109,35 +112,65 @@ struct ContainerTraits_Impl<
       typename ContainerTraits_Impl<void, Prop...>::memory_space;
   using HostMirrorSpace =
       typename ContainerTraits_Impl<void, Prop...>::HostMirrorSpace;
+  using memory_traits =
+      typename ContainerTraits_Impl<void, Prop...>::memory_traits;
 };
 
 template <class Space, class... Prop>
 struct ContainerTraits_Impl<
     typename std::enable_if<Kokkos::Impl::is_space<Space>::value>::type, Space,
     Prop...> {
-  // Specify Space, there should not be any other subsequent arguments.
+  // Specify Space, memory traits should be the only subsequent argument.
 
   static_assert(
-      std::is_same<typename ContainerTraits_Impl<void, Prop...>::index_type,
-                   void>::value &&
-          std::is_same<
-              typename ContainerTraits_Impl<void, Prop...>::execution_space,
-              void>::value &&
+      std::is_same<
+          typename ContainerTraits_Impl<void, Prop...>::execution_space,
+          void>::value &&
           std::is_same<
               typename ContainerTraits_Impl<void, Prop...>::memory_space,
               void>::value &&
           std::is_same<
               typename ContainerTraits_Impl<void, Prop...>::array_layout,
               void>::value,
-      "Space is the final optional template argument for a Container");
+      "Only one Container Execution or Memory Space template argument");
 
-  using index_type = typename ContainerTraits_Impl<void, Prop...>::index_type;
-  using array_layout =
-      typename ContainerTraits_Impl<void, Prop...>::array_layout;
+  using index_type      = void;
+  using array_layout    = void;
   using execution_space = typename Space::execution_space;
   using memory_space    = typename Space::memory_space;
   using HostMirrorSpace =
       typename Kokkos::Impl::HostMirror<Space>::Space::memory_space;
+  using memory_traits =
+      typename ContainerTraits_Impl<void, Prop...>::memory_traits;
+};
+
+template <class MemoryTraits, class... Prop>
+struct ContainerTraits_Impl<typename std::enable_if<Kokkos::is_memory_traits<
+                                MemoryTraits>::value>::type,
+                            MemoryTraits, Prop...> {
+  // Specify memory trait, should not be any subsequent arguments
+
+  static_assert(
+      std::is_same<
+          typename ContainerTraits_Impl<void, Prop...>::execution_space,
+          void>::value &&
+          std::is_same<
+              typename ContainerTraits_Impl<void, Prop...>::memory_space,
+              void>::value &&
+          std::is_same<
+              typename ContainerTraits_Impl<void, Prop...>::array_layout,
+              void>::value &&
+          std::is_same<
+              typename ContainerTraits_Impl<void, Prop...>::memory_traits,
+              void>::value,
+      "MemoryTrait is the final optional template argument for a Container");
+
+  using index_type      = void;
+  using execution_space = void;
+  using memory_space    = void;
+  using HostMirrorSpace = void;
+  using array_layout    = void;
+  using memory_traits   = MemoryTraits;
 };
 
 template <template <class, class...> class Container, class ValueType,
@@ -168,6 +201,10 @@ struct ContainerTraits {
       typename prop::HostMirrorSpace,
       typename Kokkos::Impl::HostMirror<ExecutionSpace>::Space>::type;
 
+  using MemoryTraits = typename std::conditional<
+      !std::is_same<typename prop::memory_traits, void>::value,
+      typename prop::memory_traits, typename Kokkos::MemoryManaged>::type;
+
   // Check the validity of ValueType
   static_assert(std::is_arithmetic_v<ValueType>,
                 "ValueType must be an arithmetic type such as int or double");
@@ -187,9 +224,11 @@ struct ContainerTraits {
   using execution_space   = ExecutionSpace;
   using memory_space      = MemorySpace;
   using device_type       = Kokkos::Device<ExecutionSpace, MemorySpace>;
+  using memory_traits     = MemoryTraits;
   using host_mirror_space = HostMirrorSpace;
 
-  using type = Container<value_type, index_type, array_layout, execution_space>;
+  using type = Container<value_type, index_type, array_layout, execution_space,
+                         memory_traits>;
   using HostMirror =
       Container<non_const_value_type, non_const_index_type, array_layout,
                 typename host_mirror_space::execution_space>;
@@ -202,6 +241,7 @@ struct ContainerTraits {
       typename std::add_const<type>::type>::type;
 
   enum { is_hostspace = std::is_same<MemorySpace, Kokkos::HostSpace>::value };
+  enum { is_managed = MemoryTraits::is_unmanaged == 0 };
 };
 
 }  // namespace Impl

--- a/core/tests/Coo/Test_MirrorContainers.hpp
+++ b/core/tests/Coo/Test_MirrorContainers.hpp
@@ -43,7 +43,7 @@ TEST(TESTSUITE_NAME, Mirror_CooMatrix_HostMirror) {
 
   static_assert(
       std::is_same<typename mirror::type,
-                   typename container::HostMirror>::value,
+                   typename container::HostMirror::type>::value,
       "Mirror type should match the HostMirror type of the original container "
       "as we are creating a mirror in the same space.");
 

--- a/core/tests/Csr/Test_MirrorContainers.hpp
+++ b/core/tests/Csr/Test_MirrorContainers.hpp
@@ -43,7 +43,7 @@ TEST(TESTSUITE_NAME, Mirror_CsrMatrix_HostMirror) {
 
   static_assert(
       std::is_same<typename mirror::type,
-                   typename container::HostMirror>::value,
+                   typename container::HostMirror::type>::value,
       "Mirror type should match the HostMirror type of the original container "
       "as we are creating a mirror in the same space.");
 

--- a/core/tests/DenseMatrix/Test_MirrorContainers.hpp
+++ b/core/tests/DenseMatrix/Test_MirrorContainers.hpp
@@ -41,7 +41,7 @@ TEST(TESTSUITE_NAME, Mirror_DenseMatrix_HostMirror) {
 
   static_assert(
       std::is_same<typename mirror::type,
-                   typename container::HostMirror>::value,
+                   typename container::HostMirror::type>::value,
       "Mirror type should match the HostMirror type of the original container "
       "as we are creating a mirror in the same space.");
 

--- a/core/tests/DenseVector/Test_MirrorContainers.hpp
+++ b/core/tests/DenseVector/Test_MirrorContainers.hpp
@@ -41,7 +41,7 @@ TEST(TESTSUITE_NAME, Mirror_DenseVector_HostMirror) {
 
   static_assert(
       std::is_same<typename mirror::type,
-                   typename container::HostMirror>::value,
+                   typename container::HostMirror::type>::value,
       "Mirror type should match the HostMirror type of the original container "
       "as we are creating a mirror in the same space.");
 

--- a/core/tests/Dia/Test_MirrorContainers.hpp
+++ b/core/tests/Dia/Test_MirrorContainers.hpp
@@ -41,7 +41,7 @@ TEST(TESTSUITE_NAME, Mirror_DiaMatrix_HostMirror) {
   using mirror  = decltype(A_mirror);
 
   static_assert(std::is_same<typename mirror::type,
-                             typename container::HostMirror>::value,
+                             typename container::HostMirror::type>::value,
                 "Mirror type should match the HostMirror type of the "
                 "original container "
                 "as we are creating a mirror in the same space.");


### PR DESCRIPTION
- [x] Add memory trait in ContainerTraits
- [x] Add unmanaged memory functionality to DenseVector
- [x] Add unmanaged memory functionality to CooMatrix
- [x] Add unmanaged memory functionality to CsrMatrix
- [x] Add unmanaged memory functionality to DiaMatrix
- [x] Add unmanaged memory functionality to DenseMatrix
- [x] Add unmanaged memory functionality to DynamicMatrix (No changes here as we can use the constructor from another matrix format)
- [x] Add example for unmanaged memory
- [ ] Check if unmanaged memory works for Cuda pointers and what happens when you construct from device unmanaged memory but on host i.e `Morpheus::DenseVector<double, Serial> x("x", n, v_d);` where `v_d` is a cuda pointer.